### PR TITLE
t.geoserver.publish: make the OUTPUTFOLDER env VAR dependent on GEOSERVER_DATAPATH

### DIFF
--- a/t.geoserver.publish/t.geoserver.publish.html
+++ b/t.geoserver.publish/t.geoserver.publish.html
@@ -8,13 +8,13 @@ of a space-time raster dataset (STRDS) to a GeoServer. The following environment
   <li>GEOSERVER_USER</li>
   <li>GEOSERVER_PASSWORD</li>
   <li>GEOSERVER_WORKSPACE</li>
-  <li>OUTPUTFOLDER</li>
 </ul>
 In case a shared directory between GRASS GIS and GeoServer is possible,
-another environment variable can be used to tell GeoServer to publish data
+two further environment variables can be used to tell GeoServer to publish data
 from this local path instead of uploading the data:
 <ul>
-  <li>GEOSERVER_DATAPATH</li>
+  <li>OUTPUTFOLDER (path from GRASS GIS to shared directory)</li>
+  <li>GEOSERVER_DATAPATH (path from GeoServer to shared directory)</li>
 </ul>
 There are two ways to publish GeoServer layers with <em>t.geoserver.publish</em>:
 <p>

--- a/t.geoserver.publish/t.geoserver.publish.py
+++ b/t.geoserver.publish/t.geoserver.publish.py
@@ -511,7 +511,6 @@ def main():
                 geoserver_auth,
             )
             rm_dirs.append(outputfolder)
-            rm_files.append(zip_name)
             layernames.append(mosaic_layername)
 
     # style the layer(s)

--- a/t.geoserver.publish/t.geoserver.publish.py
+++ b/t.geoserver.publish/t.geoserver.publish.py
@@ -302,9 +302,9 @@ def main():
     # if no shared folder exists, the OUTPUTFOLDER (where to store the temporary zip)
     # does not matter, hence it can be a temp dir
     if geoserver_datapath:
-        outputfolder = grass.tempdir()
-    else:
         outputfolder = get_env("OUTPUTFOLDER")
+    else:
+        outputfolder = grass.tempdir()
 
     layer_suffix = 1
     layernames = list()

--- a/t.geoserver.publish/t.geoserver.publish.py
+++ b/t.geoserver.publish/t.geoserver.publish.py
@@ -100,9 +100,9 @@ def cleanup():
         os.remove(rm_file)
 
 
-def get_env(envname):
+def get_env(envname, required=True):
     env = os.getenv(envname)
-    if env is None:
+    if env is None and required is True:
         grass.fatal(_(f"Environment variable {envname} not defined."))
     else:
         return env
@@ -295,11 +295,16 @@ def main():
     geoserver_user = get_env("GEOSERVER_USER")
     geoserver_pw = get_env("GEOSERVER_PASSWORD")
     geoserver_workspace = get_env("GEOSERVER_WORKSPACE")
-    outputfolder = get_env("OUTPUTFOLDER")
     # geoserver_datapath can be empty if no shared folder
     # between GRASS GIS and GeoServer is allowed, so
     # data will be uploaded instead of shared.
-    geoserver_datapath = os.getenv("GEOSERVER_DATAPATH")
+    geoserver_datapath = get_env("GEOSERVER_DATAPATH", required=False)
+    # if no shared folder exists, the OUTPUTFOLDER (where to store the temporary zip)
+    # does not matter, hence it can be a temp dir
+    if geoserver_datapath:
+        outputfolder = grass.tempdir()
+    else:
+        outputfolder = get_env("OUTPUTFOLDER")
 
     layer_suffix = 1
     layernames = list()
@@ -395,7 +400,7 @@ def main():
         if not geoserver_datapath:
             # Case when GRASS GIS and GeoServer don't share a common directory
             output_uuid = str(uuid.uuid4())
-            targetdir_grass = f"{targetdir_grass}/{output_uuid}"
+            targetdir_grass = os.path.join(targetdir_grass, output_uuid)
         if not os.path.isdir(targetdir_grass):
             os.makedirs(targetdir_grass)
         # if the dir exists and has files, cancel
@@ -505,7 +510,7 @@ def main():
                 geoserver_port,
                 geoserver_auth,
             )
-            rm_dirs.append(targetdir_grass)
+            rm_dirs.append(outputfolder)
             rm_files.append(zip_name)
             layernames.append(mosaic_layername)
 


### PR DESCRIPTION
If no `GEOSERVER_DATAPATH` env var exists, t.geoserver.publish uses the REST interface to upload a zip to geoserver. This means the `OUTPUTFOLDER` env var is not required in this case, as it can be any temporary directory. 