### PR TITLE
t.geoserver.publish: limit color options to those GeoServer can handle

### DIFF
--- a/t.geoserver.publish/t.geoserver.publish.py
+++ b/t.geoserver.publish/t.geoserver.publish.py
@@ -44,7 +44,7 @@
 # % type: string
 # % required: no
 # % multiple: no
-# % options: bcyr,bgyr,blues,byg,byr,elevation,evi,forest_cover,grass,greens,grey,gyr,ndvi,ndwi,reds,ryb,ryg
+# % options: bcyr,bgyr,blues,byg,byr,default,elevation,evi,forest_cover,grass,greens,grey,gyr,ndvi,ndwi,reds,ryb,ryg
 # % label: Name of color table for layer styling
 # %end
 
@@ -288,6 +288,8 @@ def main():
     layername_prefix = options["layername_prefix"]
     mosaic_layername = options["mosaic_layername"]
     color = options["color"]
+    if color == "default":
+        color = None
     color_rules = get_color_rules()
 
     # get env variables


### PR DESCRIPTION
This PR adapts `t.geoserver.publish` to limit color options to those that GeoServer can handle. For color scales like `magma, viridis`, etc. the GRASS color definition is so long that the output SLD is not accepted as GeoServer style. It is still possible to not provide a color (either by not filling the color parameter or choosing the `default` value), in which case the result will be in grey values. 

This has the nice side effect that a drop-down menu with the available options is shown if the module is called via the OpenEO WebEditor